### PR TITLE
fix: release 1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,7 +232,7 @@ jobs:
           name: android-artifacts
           path: android-release
 
-      - name: Upload Android APK to release
+      - name: Upload Android artifacts to release
         uses: actions/github-script@v8
         env:
           release_id: ${{ needs.create-release.outputs.release_id }}
@@ -240,42 +240,43 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const glob = require('glob');
 
-            // Find APK files
-            const apkFiles = glob.sync('android-release/**/*.apk');
-
-            for (const apkFile of apkFiles) {
-              const fileName = path.basename(apkFile);
-              const fileContent = fs.readFileSync(apkFile);
+            // Function to recursively find files with specific extensions
+            function findFiles(dir, extensions) {
+              const files = [];
               
-              await github.rest.repos.uploadReleaseAsset({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                release_id: process.env.release_id,
-                name: fileName,
-                data: fileContent,
-              });
+              function searchDir(currentDir) {
+                const items = fs.readdirSync(currentDir);
+                
+                for (const item of items) {
+                  const fullPath = path.join(currentDir, item);
+                  const stat = fs.statSync(fullPath);
+                  
+                  if (stat.isDirectory()) {
+                    searchDir(fullPath);
+                  } else if (extensions.some(ext => item.endsWith(ext))) {
+                    files.push(fullPath);
+                  }
+                }
+              }
               
-              console.log(`Uploaded ${fileName} to release`);
+              if (fs.existsSync(dir)) {
+                searchDir(dir);
+              }
+              
+              return files;
             }
 
-      - name: Upload Android AAB to release
-        uses: actions/github-script@v8
-        env:
-          release_id: ${{ needs.create-release.outputs.release_id }}
-        with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const glob = require('glob');
+            // Find APK and AAB files
+            const androidFiles = findFiles('android-release', ['.apk', '.aab']);
 
-            // Find AAB files
-            const aabFiles = glob.sync('android-release/**/*.aab');
+            console.log(`Found ${androidFiles.length} Android files to upload`);
 
-            for (const aabFile of aabFiles) {
-              const fileName = path.basename(aabFile);
-              const fileContent = fs.readFileSync(aabFile);
+            for (const androidFile of androidFiles) {
+              const fileName = path.basename(androidFile);
+              const fileContent = fs.readFileSync(androidFile);
+              
+              console.log(`Uploading ${fileName} (${fileContent.length} bytes)`);
               
               await github.rest.repos.uploadReleaseAsset({
                 owner: context.repo.owner,
@@ -285,7 +286,7 @@ jobs:
                 data: fileContent,
               });
               
-              console.log(`Uploaded ${fileName} to release`);
+              console.log(`Successfully uploaded ${fileName} to release`);
             }
 
       - name: publish release


### PR DESCRIPTION
This pull request simplifies and unifies the process of uploading Android build artifacts (APK and AAB files) to GitHub releases in the workflow configuration. Previously, APKs and AABs were handled in separate steps using the `glob` package; now, both are processed together using a custom recursive file search function, reducing duplication and improving maintainability.

**Workflow improvements:**

* Combined the upload steps for Android APK and AAB files into a single step, using a custom `findFiles` function to recursively locate all `.apk` and `.aab` files in the `android-release` directory. This replaces the previous approach that used the `glob` package in two separate steps.
* Improved log output to indicate the number of Android files found and provide more informative upload status messages. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L235-R279) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L288-R289)